### PR TITLE
addresses light artifact when `param = "light"` is missing

### DIFF
--- a/cheese_rack.lua
+++ b/cheese_rack.lua
@@ -90,7 +90,7 @@ local cheese_rack_with_aging_cheese = {
 		"default_wood.png^fresh_cheese_front.png"
 	},
 	drawtype = "nodebox",
-	--paramtype = "light",
+	paramtype = "light",
 	paramtype2 = "facedir",
 	groups = {choppy=2},
 	sounds = default.node_sound_wood_defaults(),


### PR DESCRIPTION
Addresses issue #3 